### PR TITLE
 Add compatibility to be driven by HTTP input POST node

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,32 @@ The filename being written to can be overridden by setting
 The document to be added should be passed in as a data buffer
 in `msg.payload`.
 
+### HTTP Input
+The node can also be driven by a HTTP input node, where a pdf
+file is POSTed to the flow. The pdf file buffer and name will
+then be taken from the request field of the `msg`.
+To use this implementation, in the http input properties, ensure
+that "Method" is set to "POST", and "Accept file uploads?" is
+ticked.
+
 ### Output
 The output is a json object on `msg.payload`.
 If the split option is selected then an event is sent for each page.
 
 ### Sample flow
+File Inject Implementation
 ````
 [{"id":"75540143.de239","type":"pdf-hummus","z":"434de041.4e4f4","name":"","filename":"myfile.txt","split":true,"mode":{"value":"asBuffer"},"x":270.5,"y":65,"wires":[["cd04c7ce.3b70c8","a84e0874.451318"]]},{"id":"38aade4f.ab0c12","type":"fileinject","z":"434de041.4e4f4","name":"","x":103,"y":62,"wires":[["75540143.de239"]]},{"id":"cd04c7ce.3b70c8","type":"debug","z":"434de041.4e4f4","name":"","active":true,"console":"false","complete":"false","x":449.5,"y":65,"wires":[]},{"id":"a84e0874.451318","type":"watson-discovery-v1-document-loader","z":"434de041.4e4f4","name":"","environment_id":"","collection_id":"","default-endpoint":true,"service-endpoint":"https://gateway.watsonplatform.net/discovery/api","x":411,"y":133,"wires":[["2e9ac940.1cd4c6"]]},{"id":"2e9ac940.1cd4c6","type":"debug","z":"434de041.4e4f4","name":"","active":true,"console":"false","complete":"true","x":610.5,"y":131,"wires":[]}]
 ````
+HTTP POST Implementation
+````
+[ { "id": "1f7ebf39.38b309", "type": "pdf-hummus", "z": "639c38eb.3b18c8", "name": "", "filename": "", "split": false, "mode": { "value": "asBuffer" }, "x": 487, "y": 227, "wires": [ [ "757b38a5.04059" ] ] }, { "id": "e8e6b15b.868638", "type": "http in", "z": "639c38eb.3b18c8", "name": "", "url": "/pdfin", "method": "post", "upload": true, "swaggerDoc": "", "x": 204, "y": 228, "wires": [ [ "1f7ebf39.38b309" ] ] }, { "id": "757b38a5.04059", "type": "http response", "z": "639c38eb.3b18c8", "name": "", "statusCode": "200", "headers": {}, "x": 792, "y": 230, "wires": [] } ]
+````
+Deploy the sample flow, and create a HTTP POST as follows:
+- METHOD: POST
+- URL: http://localhost:1800/pdfin
+- BODY_TYPE: form-data
+- HEADERS: Key - "file" Value - target.pdf
 
 ## Contributing
 For simple typos and fixes please just raise an issue pointing out our mistakes. If you need to raise a pull request please read our [contribution guidelines](https://github.com/ibm-early-programs/node-red-contrib-pdf-hummus/blob/master/CONTRIBUTING.md) before doing so.

--- a/nodes/v1.js
+++ b/nodes/v1.js
@@ -25,16 +25,23 @@ module.exports = function(RED) {
   temp.track();
 
   function verifyPayload(msg) {
-    // If the node is in a flow driven by a HTTP POST, use the relevant fields for the payload and filename.
+    var httpPostData = {}
+    // If the node is in a flow driven by a HTTP POST, store the relevant fields for the buffer and filename.
+    // This will give priority to the buffer being passed through the msg.payload, allowing for the event of
+    // the file being sent via HTTP POST and then being updated prior to this node. 
     if(!!msg.req && !!msg.req.files && msg.req.files.length > 0 && !!msg.req.files[0].buffer && msg.req.files[0].mimetype === "application/pdf" && msg.req.files[0].buffer instanceof Buffer){
-        msg.payload = msg.req.files[0].buffer;
-        msg.filename = msg.req.files[0].originalname;
+      httpPostData.buffer = msg.req.files[0].buffer;
+      httpPostData.filename = msg.req.files[0].originalname;
     }
       
-    if (!msg.payload) {
+    if (!msg.payload && !httpPostData.buffer) {
       return Promise.reject('Missing property: msg.payload');
     } else if (msg.payload instanceof Buffer) {
-            return Promise.resolve();
+      return Promise.resolve();
+    } else if (!!httpPostData.buffer) {
+      msg.payload = httpPostData.buffer;
+      msg.filename = httpPostData.filename;
+      return Promise.resolve();
     } else {
       return Promise.reject('msg.payload should be pdf buffer');
     }

--- a/nodes/v1.js
+++ b/nodes/v1.js
@@ -25,6 +25,12 @@ module.exports = function(RED) {
   temp.track();
 
   function verifyPayload(msg) {
+    // If the node is in a flow driven by a HTTP POST, use the relevant fields for the payload and filename.
+    if(!!msg.req && !!msg.req.files && msg.req.files.length > 0 && !!msg.req.files[0].buffer && msg.req.files[0].mimetype === "application/pdf" && msg.req.files[0].buffer instanceof Buffer){
+        msg.payload = msg.req.files[0].buffer;
+        msg.filename = msg.req.files[0].originalname;
+    }
+      
     if (!msg.payload) {
       return Promise.reject('Missing property: msg.payload');
     } else if (msg.payload instanceof Buffer) {


### PR DESCRIPTION
A strong use-case for this node is the parsing of PDFs that have been POSTed via a HTTP endpoint. To make this work, a function node is required to move the file buffer from the request files array, but it would be more useful to detect this input and shift the data natively.